### PR TITLE
Use Buffer.alloc instead of Buffer.from

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -1209,7 +1209,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function (filename, flag) {
   const self = this;
 
   let erroredOut = false;
-  let slurpBuf = Buffer.from(1024);
+  let slurpBuf = Buffer.alloc(1024);
   let totalBytes = 0;
   const startTime = new Date();
 
@@ -1258,7 +1258,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function (filename, flag) {
           newLength = totalBytes + buf.length;
         }
 
-        const newSlurpBuf = Buffer.from(newLength);
+        const newSlurpBuf = Buffer.alloc(newLength);
         slurpBuf.copy(newSlurpBuf, 0, 0, totalBytes);
         slurpBuf = newSlurpBuf;
       }


### PR DESCRIPTION
This PR fixes a regression introduced in the latest refactoring:
TypeError [ERR_INVALID_ARG_TYPE]: The "value" argument must not be of type number. Received type number
    at Function.from (buffer.js:215:11)
    at FtpConnection._STOR_usingWriteFile (/data/node_modules/ftpd/lib/FtpConnection.js:1212:25)
    at FtpConnection._command_STOR (/data/node_modules/ftpd/lib/FtpConnection.js:1122:10)
    at checkData (/data/node_modules/ftpd/lib/FtpConnection.js:291:14)
    at FtpConnection._onData (/data/node_modules/ftpd/lib/FtpConnection.js:279:9)
    at Socket.socket.on (/data/node_modules/ftpd/lib/FtpServer.js:102:10)

I've tested the ftp file upload with this change and everything seems to work fine!