### PR TITLE
Fix file modes

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -25,6 +25,9 @@ const LOG = Constants.LOG_LEVELS;
 const { DOES_NOT_REQUIRE_AUTH } = Constants;
 const { REQUIRES_CONFIGURED_DATA } = Constants;
 
+const MODE_755 = 0x1ed;
+const MODE_644 = 0x1a4;
+
 function FtpConnection(properties) {
   EventEmitter.call(this);
   const self = this;
@@ -643,7 +646,7 @@ FtpConnection.prototype._command_MKD = function (pathRequest) {
   const pathServer = withCwd(this.cwd, pathRequest);
   const pathEscaped = pathEscape(pathServer);
   const pathFs = pathModule.join(this.root, pathServer);
-  this.fs.mkdir(pathFs, 755, (err) => {
+  this.fs.mkdir(pathFs, MODE_755, (err) => {
     if (err) {
       this._logIf(LOG.ERROR, `MKD ${pathRequest}: ${err}`);
       this.respond(`550 "${pathEscaped}" directory NOT created`);
@@ -1129,7 +1132,7 @@ FtpConnection.prototype._command_STOR = function (commandArg) {
 FtpConnection.prototype._STOR_usingCreateWriteStream = function (filename, initialBuffers, flag) {
   const self = this;
 
-  const wStreamFlags = { flags: flag || 'w', mode: 644 };
+  const wStreamFlags = { flags: flag || 'w', mode: MODE_644 };
   const storeStream = self.fs.createWriteStream(pathModule.join(self.root, filename), wStreamFlags);
   let notErr = true;
   // Adding for event metadata for file upload (STOR)
@@ -1272,7 +1275,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function (filename, flag) {
       return;
     }
 
-    const wOptions = { flag: flag || 'w', mode: 644 };
+    const wOptions = { flag: flag || 'w', mode: MODE_644 };
     const contents = { filename, data: slurpBuf.slice(0, totalBytes) };
     self.emit('file:stor:contents', contents);
     self.fs.writeFile(pathModule.join(self.root, filename), contents.data, wOptions, (err) => {


### PR DESCRIPTION
The file mode numbers were octal values before the last refactoring.
This PR sets the right values.